### PR TITLE
fix parsing unstable options with hypthen's in the value

### DIFF
--- a/lib/jvmargs/unstable.rb
+++ b/lib/jvmargs/unstable.rb
@@ -6,7 +6,7 @@ module JVMArgs
     def initialize(arg)
       stripped = arg.sub(/^-?XX:/, '')
       # check it if a boolean option
-      stripped =~ /(\+|-)(.*)/
+      stripped =~ /^(\+|-)(.*)$/
       if !$1.nil?
         @key = $2
         @value = $1 == '+' ? true : false

--- a/spec/jvmargs/unstable_spec.rb
+++ b/spec/jvmargs/unstable_spec.rb
@@ -37,4 +37,10 @@ describe JVMArgs::Unstable do
 
     expect(initial_arg).to eq "-XX:AltStackSize=16384"
   end
+
+  it "should parse paths with '-' in them" do
+    arg = JVMArgs::Unstable.new("-XX:ErrorPath=/var/thing-that/foo-bar")
+    expect(arg.key).to eq("ErrorPath")
+    expect(arg.value).to eq("/var/thing-that/foo-bar")
+  end
 end


### PR DESCRIPTION
the specific use is that paths can have '-' in them for example
-XX:ErrorPath=/var/foo-bar is in theory perfectly legal.
